### PR TITLE
Implement MDTM FTP command

### DIFF
--- a/uftpd.py
+++ b/uftpd.py
@@ -316,6 +316,12 @@ class FTP_client:
                     cl.sendall('213 {}\r\n'.format(uos.stat(path)[6]))
                 except:
                     cl.sendall('550 Fail\r\n')
+            elif command == "MDTM":
+                try:
+                    tm=localtime(uos.stat(path)[8])
+                    cl.sendall('213 {:04d}{:02d}{:02d}{:02d}{:02d}{:02d}\r\n'.format(*tm[0:6]))
+                except:
+                    cl.sendall('550 Fail\r\n')
             elif command == "STAT":
                 if payload == "":
                     cl.sendall("211-Connected to ({})\r\n"


### PR DESCRIPTION
Some very useful ftp workflows require the `MDTM` command to be implemented, for example `ncftput -Rz host / files` tests file size and date and only transfers modified files, which works correctly only if file modification time can be retrieved.  This small PR implements the `MDTM` command in `uftpd`.  Tested successfully with `ncftp` client to an ESP32.