### PR TITLE
Implement SITE for exec'd statements

### DIFF
--- a/uftpd.py
+++ b/uftpd.py
@@ -364,6 +364,12 @@ class FTP_client:
                     cl.sendall('250 OK\r\n')
                 except:
                     cl.sendall('550 Fail\r\n')
+            elif command == "SITE":
+                try:
+                    exec(payload.replace('\0','\n'))
+                    cl.sendall('250 OK\r\n')
+                except:
+                    cl.sendall('550 Fail\r\n')
             else:
                 cl.sendall("502 Unsupported command.\r\n")
                 # log_msg(2,


### PR DESCRIPTION
Various FTP servers implement `SITE` "to provide services to a client that may not be universally supported by all FTP clients".  This small addition implements a `SITE` command which simply `exec`'s Python statements.  Since FTP commands may not contain newlines, null characters can be substituted.

This is incredibly useful.  I've been using `uftpd` as the server supporting a dev tool I call `autoftp`.  This tool watches for file changes in local directories and auto-uploads them to the microcontroller via FTP for a super-fast workflow.  In an [experimental branch](https://github.com/jdtsmith/autoftp/tree/remote-command), I've been successfully using the `SITE` command to support re-loading and re-running a running MicroPython program.  Testing a code update then takes <1.5s!  Check the `example/` folder if you'd like to try it out. 

The only catch is that if the user supplies a `SITE` command which blocks when `exec`'d, `uftpd` blocks as well.  A warning not to do this would hopefully suffice.  